### PR TITLE
Added require for 'active_admin'

### DIFF
--- a/lib/active_admin_importable.rb
+++ b/lib/active_admin_importable.rb
@@ -1,6 +1,7 @@
 require "active_admin_importable/version"
 require 'active_admin_importable/engine'
 require 'active_admin_importable/dsl'
+require 'active_admin'
 
 ::ActiveAdmin::DSL.send(:include, ActiveAdminImportable::DSL)
 


### PR DESCRIPTION
Fix for Ruby 1.9.2 and greater.
