### PR TITLE
Parser options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ ActiveAdmin.register Product do
 end
 ```
 
+## Parsing Options
+
+ActiveAdminImportable uses [CSV.parse](http://ruby-doc.org/stdlib-2.2.2/libdoc/csv/rdoc/CSV.html#method-c-parse) to parse your uploaded CSV. You can pass in any standard options via the optional param to active_admin_importable:
+
+```
+ActiveAdmin.register Product do
+  active_admin_importable(
+    col_sep: ':',
+    quote_char: "'",
+    header_converters: ->(h) { h.underscore.to_sym }
+  )
+end
+```
+
 ## Contributing
 
 1. Fork it

--- a/app/models/csv_db.rb
+++ b/app/models/csv_db.rb
@@ -5,7 +5,11 @@ class CsvDb
       csv_file = csv_data.read
       CSV.parse(csv_file, :headers => true, header_converters: :symbol ) do |row|
         target_model = model_name.classify.constantize
-        target_model.create!(row.to_hash)
+        if( target_model.respond_to? 'import_from_hash' ) 
+          target_model.import_from_hash( row.to_hash )
+        else
+          target_model.create!(row.to_hash)
+        end
       end
     end
   end

--- a/app/models/csv_db.rb
+++ b/app/models/csv_db.rb
@@ -1,9 +1,10 @@
 require 'csv'
 class CsvDb
   class << self
-    def convert_save(target_model, csv_data, &block)
+    def convert_save(target_model, csv_data, options = {}, &block)
+      options = {:headers => true, header_converters: :symbol}.merge(options)
       csv_file = csv_data.read
-      CSV.parse(csv_file, :headers => true, header_converters: :symbol ) do |row|
+      CSV.parse(csv_file, options) do |row|
         data = row.to_hash
         if data.present?
           if (block_given?)

--- a/lib/active_admin_importable/dsl.rb
+++ b/lib/active_admin_importable/dsl.rb
@@ -1,6 +1,6 @@
 module ActiveAdminImportable
   module DSL
-    def active_admin_importable(&block)
+    def active_admin_importable(opts = {}, &block)
       action_item :only => :index do
         link_to "Import #{active_admin_config.resource_name.to_s.pluralize}", :action => 'upload_csv'
       end
@@ -10,7 +10,7 @@ module ActiveAdminImportable
       end
 
       collection_action :import_csv, :method => :post do
-        CsvDb.convert_save(active_admin_config.resource_class, params[:dump][:file], &block)
+        CsvDb.convert_save(active_admin_config.resource_class, params[:dump][:file], opts, &block)
         redirect_to :action => :index, :notice => "#{active_admin_config.resource_name.to_s} imported successfully!"
       end
     end

--- a/lib/active_admin_importable/version.rb
+++ b/lib/active_admin_importable/version.rb
@@ -1,3 +1,3 @@
 module ActiveAdminImportable
-  VERSION = "1.1.2"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
Added ability to pass in options to CSV.parse and override default options.

Resolves #17 and #24 by providing option to override default `:symbol` behavior.
