### PR TITLE
Fix action_item deprecation warning

### DIFF
--- a/lib/active_admin_importable/dsl.rb
+++ b/lib/active_admin_importable/dsl.rb
@@ -1,7 +1,7 @@
 module ActiveAdminImportable
   module DSL
     def active_admin_importable(&block)
-      action_item :only => :index do
+      action_item :edit, :only => :index do
         link_to "Import #{active_admin_config.resource_name.to_s.pluralize}", :action => 'upload_csv'
       end
 


### PR DESCRIPTION
This passes the requested `:edit` action to the `action_item`, so cleans up the deprecation warning with the latest Active Admin versions.
