### PR TITLE
Fix action_item deprication

### DIFF
--- a/lib/active_admin_importable/dsl.rb
+++ b/lib/active_admin_importable/dsl.rb
@@ -1,7 +1,7 @@
 module ActiveAdminImportable
   module DSL
     def active_admin_importable(&block)
-      action_item :only => :index do
+      action_item(:index) do
         link_to "Import #{active_admin_config.resource_name.to_s.pluralize}", :action => 'upload_csv'
       end
 


### PR DESCRIPTION
Simple syntax change to get rid of deprication warnings when running
specs, etc.

Docs on this:
http://activeadmin.info/docs/10-custom-pages.html
