### PR TITLE
Fix active_admin deprecation warning

### DIFF
--- a/lib/active_admin_importable/dsl.rb
+++ b/lib/active_admin_importable/dsl.rb
@@ -1,7 +1,7 @@
 module ActiveAdminImportable
   module DSL
     def active_admin_importable(&block)
-      action_item :only => :index do
+      action_item(:index) do
         link_to "Import #{active_admin_config.resource_name.to_s.pluralize}", :action => 'upload_csv'
       end
 


### PR DESCRIPTION
I forked this gem and fixed the following deprecation warning.

![screen shot 2016-10-03 at 12 08 21 pm](https://cloud.githubusercontent.com/assets/1596423/19050179/554cd3d4-8962-11e6-8f36-8b025b4b4248.png)
