### PR TITLE
Update to tidy a few Active_Admin_Importable glitches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+# RubyMine project files
+.idea

--- a/active_admin_importable.gemspec
+++ b/active_admin_importable.gemspec
@@ -8,6 +8,8 @@ Gem::Specification.new do |gem|
   gem.summary       = "Add CSV import to Active Admin resources with one line."
   gem.homepage      = "http://github.com/krhorst/active_admin_importable"
 
+  gem.add_runtime_dependency 'rchardet', '~> 1.6'
+
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})

--- a/app/models/csv_db.rb
+++ b/app/models/csv_db.rb
@@ -1,17 +1,19 @@
 require 'csv'
+
 class CsvDb
   class << self
     def convert_save(target_model, csv_data, &block)
       csv_file = csv_data.read
+
       CSV.parse(csv_file, :headers => true, header_converters: :symbol ) do |row|
         data = row.to_hash
         if data.present?
           if (block_given?)
              block.call(target_model, data)
-           else
+          else
              target_model.create!(data)
-           end
-         end
+          end
+        end
       end
     end
   end

--- a/app/models/csv_db.rb
+++ b/app/models/csv_db.rb
@@ -3,17 +3,21 @@ require 'rchardet'
 
 class CsvDb
   class << self
-    def convert_save(target_model, csv_data, &block)
+    def convert_save(target_model, csv_data, validator, &block)
       csv_file = csv_data.read
       encoding = CharDet.detect(csv_file)['encoding']
       csv_file.encode!('UTF-8', encoding)
-      CSV.parse(csv_file, :headers => true, header_converters: :symbol ) do |row|
+
+      dataset = CSV.parse(csv_file, :headers => true, header_converters: :symbol)
+      validator.call(dataset) if validator.present?
+
+      dataset.each do |row|
         data = row.to_hash
         if data.present?
           if (block_given?)
-             block.call(target_model, data)
+            block.call(target_model, data)
           else
-             target_model.create!(data)
+            target_model.create!(data)
           end
         end
       end

--- a/app/models/csv_db.rb
+++ b/app/models/csv_db.rb
@@ -1,10 +1,12 @@
 require 'csv'
+require 'rchardet'
 
 class CsvDb
   class << self
     def convert_save(target_model, csv_data, &block)
       csv_file = csv_data.read
-
+      encoding = CharDet.detect(csv_file)['encoding']
+      csv_file.encode!('UTF-8', encoding)
       CSV.parse(csv_file, :headers => true, header_converters: :symbol ) do |row|
         data = row.to_hash
         if data.present?

--- a/app/views/admin/csv/upload_csv.html.erb
+++ b/app/views/admin/csv/upload_csv.html.erb
@@ -1,22 +1,17 @@
-<%= form_for :dump, :url => {:action => "import_csv"}, :html => {:multipart => true} do |f| %>
-
-     <table>
-
-       <tr>
-         <td>
-           <%= label_tag  "dump_file", "Select a CSV File" %>
-           </td>
-         <td>
-           <%= f.file_field :file %>
+<%= form_for :dump, :url => {:action => 'import_csv'}, :html => {:multipart => true} do |f| %>
+   <table>
+     <tr>
+       <td>
+         <%= label_tag  'dump_file', 'Select a CSV File' %>
          </td>
-       </tr>
-       <tr>
-         <td>
-           <%= submit_tag 'Submit' %>
-         </td>
-       </tr>
-
-     </table>
-
-
+       <td>
+         <%= f.file_field :file %>
+       </td>
+     </tr>
+     <tr>
+       <td>
+         <%= submit_tag 'Submit' %>
+       </td>
+     </tr>
+   </table>
 <% end %>

--- a/lib/active_admin_importable/dsl.rb
+++ b/lib/active_admin_importable/dsl.rb
@@ -1,8 +1,9 @@
 module ActiveAdminImportable
   module DSL
-    def active_admin_importable(&block)
+    def active_admin_importable(options={}, &block)
       action_item :only => :index do
-        link_to "Import #{active_admin_config.resource_name.to_s.pluralize}", :action => 'upload_csv'
+        link_name = options[:name] || "Import #{active_admin_config.resource_name.to_s.pluralize}"
+        link_to link_name, :action => 'upload_csv'
       end
 
       collection_action :upload_csv do
@@ -11,7 +12,7 @@ module ActiveAdminImportable
 
       collection_action :import_csv, :method => :post do
         ActiveRecord::Base.transaction do
-          CsvDb.convert_save(active_admin_config.resource_class, params[:dump][:file], options[:transaction], &block)
+          CsvDb.convert_save(active_admin_config.resource_class, params[:dump][:file], &block)
         end
         redirect_to :action => :index, :notice => "#{active_admin_config.resource_name.to_s} imported successfully!"
       end

--- a/lib/active_admin_importable/dsl.rb
+++ b/lib/active_admin_importable/dsl.rb
@@ -11,10 +11,15 @@ module ActiveAdminImportable
       end
 
       collection_action :import_csv, :method => :post do
-        ActiveRecord::Base.transaction do
-          CsvDb.convert_save(active_admin_config.resource_class, params[:dump][:file], &block)
+        begin
+          ActiveRecord::Base.transaction do
+            CsvDb.convert_save(active_admin_config.resource_class, params[:dump][:file], &block)
+          end
+          flash[:notice] = "#{active_admin_config.resource_name.to_s.pluralize} imported successfully!"
+        rescue StandardError => e
+          flash[:alert] = "Error: #{e.message}"
         end
-        flash[:notice] = "#{active_admin_config.resource_name.to_s} imported successfully!"
+
         redirect_to :action => :index
       end
     end

--- a/lib/active_admin_importable/dsl.rb
+++ b/lib/active_admin_importable/dsl.rb
@@ -1,7 +1,7 @@
 module ActiveAdminImportable
   module DSL
     def active_admin_importable(options={}, &block)
-      action_item :only => :index do
+      action_item :edit, :only => :index do
         link_name = options[:name] || "Import #{active_admin_config.resource_name.to_s.pluralize}"
         link_to link_name, :action => 'upload_csv'
       end

--- a/lib/active_admin_importable/dsl.rb
+++ b/lib/active_admin_importable/dsl.rb
@@ -6,7 +6,7 @@ module ActiveAdminImportable
       end
 
       collection_action :upload_csv do
-        render "admin/csv/upload_csv"
+        render 'admin/csv/upload_csv'
       end
 
       collection_action :import_csv, :method => :post do

--- a/lib/active_admin_importable/dsl.rb
+++ b/lib/active_admin_importable/dsl.rb
@@ -10,7 +10,9 @@ module ActiveAdminImportable
       end
 
       collection_action :import_csv, :method => :post do
-        CsvDb.convert_save(active_admin_config.resource_class, params[:dump][:file], &block)
+        ActiveRecord::Base.transaction do
+          CsvDb.convert_save(active_admin_config.resource_class, params[:dump][:file], options[:transaction], &block)
+        end
         redirect_to :action => :index, :notice => "#{active_admin_config.resource_name.to_s} imported successfully!"
       end
     end

--- a/lib/active_admin_importable/dsl.rb
+++ b/lib/active_admin_importable/dsl.rb
@@ -14,7 +14,8 @@ module ActiveAdminImportable
         ActiveRecord::Base.transaction do
           CsvDb.convert_save(active_admin_config.resource_class, params[:dump][:file], &block)
         end
-        redirect_to :action => :index, :notice => "#{active_admin_config.resource_name.to_s} imported successfully!"
+        flash[:notice] = "#{active_admin_config.resource_name.to_s} imported successfully!"
+        redirect_to :action => :index
       end
     end
   end

--- a/lib/active_admin_importable/dsl.rb
+++ b/lib/active_admin_importable/dsl.rb
@@ -13,7 +13,7 @@ module ActiveAdminImportable
       collection_action :import_csv, :method => :post do
         begin
           ActiveRecord::Base.transaction do
-            CsvDb.convert_save(active_admin_config.resource_class, params[:dump][:file], &block)
+            CsvDb.convert_save(active_admin_config.resource_class, params[:dump][:file], options[:validator], &block)
           end
           flash[:notice] = "#{active_admin_config.resource_name.to_s.pluralize} imported successfully!"
         rescue StandardError => e

--- a/lib/active_admin_importable/engine.rb
+++ b/lib/active_admin_importable/engine.rb
@@ -3,8 +3,6 @@ require 'rails'
 
 module ActiveAdminImportable
   class Engine < Rails::Engine
-
     config.mount_at = '/'
-
   end
 end

--- a/lib/active_admin_importable/version.rb
+++ b/lib/active_admin_importable/version.rb
@@ -1,3 +1,3 @@
 module ActiveAdminImportable
-  VERSION = "1.1.2"
+  VERSION = '1.1.2'
 end

--- a/lib/active_admin_importable/version.rb
+++ b/lib/active_admin_importable/version.rb
@@ -1,3 +1,3 @@
 module ActiveAdminImportable
-  VERSION = '1.1.3'
+  VERSION = '1.2.0'
 end

--- a/lib/active_admin_importable/version.rb
+++ b/lib/active_admin_importable/version.rb
@@ -1,3 +1,3 @@
 module ActiveAdminImportable
-  VERSION = '1.1.2'
+  VERSION = '1.1.3'
 end


### PR DESCRIPTION
This pull request fixes a few things that lots of people have created forks for.

* Rollback if the import crashes
* Fixing Flash message glitch
* Tell the user if there is an import error
* Try to detect the correct character encoding (if using Excel CSV this is a common issue)
* Fix annoying Active Admin message "using `action_item` without a name is deprecated"